### PR TITLE
feat: add simpleeval dependency to project requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dynamic = ["dependencies"]
+dependencies = [
+  "simpleeval >= 1.0.3"
+]
 
 [project.urls]
 Homepage = "https://github.com/lemniscat-devops/lemniscat.core"

--- a/src/lemniscat/core/requirements.txt
+++ b/src/lemniscat/core/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML==6.0.1
-simpleeval==0.9.13
+simpleeval==1.0.3


### PR DESCRIPTION
This pull request includes updates to the dependencies for the `lemniscat.core` project. The changes add a new dependency, `simpleeval`, to both the `pyproject.toml` and `requirements.txt` files.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L20-R22): Added `simpleeval >= 1.0.3` to the `dependencies` section.
* [`src/lemniscat/core/requirements.txt`](diffhunk://#diff-6face4f75c36931de05e14db991244fdd4cddd1be5c1423a76c46f5ae642699fR2): Added `simpleeval==1.0.3`.